### PR TITLE
use SystemProperty "java.io.tmpdir" instead of "/tmp"

### DIFF
--- a/src/main/java/org/italiangrid/voms/clients/impl/DefaultVOMSProxyInitBehaviour.java
+++ b/src/main/java/org/italiangrid/voms/clients/impl/DefaultVOMSProxyInitBehaviour.java
@@ -405,15 +405,16 @@ public class DefaultVOMSProxyInitBehaviour implements ProxyInitStrategy {
 		
 		List<String> proxyCreationWarnings = new ArrayList<String>();
 		
-		String proxyFilePath = VOMSProxyPathBuilder.buildProxyPath();
-		
-		String envProxyPath = System.getenv(VOMSEnvironmentVariables.X509_USER_PROXY);
-
-		if (envProxyPath != null)
-			proxyFilePath = envProxyPath;
-		
-		if (params.getGeneratedProxyFile() != null)
-			proxyFilePath = params.getGeneratedProxyFile();
+        String proxyFilePath = null;
+        if (params.getGeneratedProxyFile() != null) {
+            proxyFilePath = params.getGeneratedProxyFile();
+        } else {
+            String envProxyPath = System.getenv(VOMSEnvironmentVariables.X509_USER_PROXY);
+            if (envProxyPath != null)
+                proxyFilePath = envProxyPath;
+            else
+                proxyFilePath = VOMSProxyPathBuilder.buildProxyPath();
+        }
 		
 		ProxyCertificateOptions proxyOptions = new ProxyCertificateOptions(credential.getCertificateChain());
 		

--- a/src/main/java/org/italiangrid/voms/clients/util/VOMSProxyPathBuilder.java
+++ b/src/main/java/org/italiangrid/voms/clients/util/VOMSProxyPathBuilder.java
@@ -16,11 +16,12 @@
 package org.italiangrid.voms.clients.util;
 
 import org.italiangrid.voms.credential.ProxyNamingPolicy;
+import org.italiangrid.voms.credential.impl.DefaultLoadCredentialsStrategy;
 import org.italiangrid.voms.credential.impl.DefaultProxyPathBuilder;
 
 public class VOMSProxyPathBuilder {
 	
-	private static final String TMP_PATH = "/tmp";
+	private static final String TMP_PATH = System.getProperty(DefaultLoadCredentialsStrategy.TMPDIR_PROPERTY);
 	
 	public static String buildProxyPath(){
 		


### PR DESCRIPTION
helps voms-client API not to fail on Windows
