### PR TITLE
Change default proxy cert key length to 2048 bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ subject   : /C=IT/O=INFN/OU=Personal Certificate/L=CNAF/CN=Andrea Ceccanti/CN=pr
 issuer    : /C=IT/O=INFN/OU=Personal Certificate/L=CNAF/CN=Andrea Ceccanti
 identity  : /C=IT/O=INFN/OU=Personal Certificate/L=CNAF/CN=Andrea Ceccanti
 type      : proxy
-strength  : 1024
+strength  : 2048
 path      : /tmp/x509up_u501
 timeleft  : 11:59:48
 key usage : digitalSignature keyEncipherment dataEncipherment
@@ -122,7 +122,7 @@ subject   : /C=IT/O=INFN/OU=Personal Certificate/L=CNAF/CN=Andrea Ceccanti/CN=pr
 issuer    : /C=IT/O=INFN/OU=Personal Certificate/L=CNAF/CN=Andrea Ceccanti
 identity  : /C=IT/O=INFN/OU=Personal Certificate/L=CNAF/CN=Andrea Ceccanti
 type      : proxy
-strength  : 1024
+strength  : 2048
 path      : /tmp/x509up_u501
 timeleft  : 12:04:48
 key usage : digitalSignature keyEncipherment dataEncipherment 

--- a/src/main/java/org/italiangrid/voms/clients/ProxyInitParams.java
+++ b/src/main/java/org/italiangrid/voms/clients/ProxyInitParams.java
@@ -34,7 +34,7 @@ public class ProxyInitParams {
     .toSeconds(12);
   public static final int DEFAULT_AC_LIFETIME = (int) TimeUnit.HOURS
     .toSeconds(12);
-  public static final int DEFAULT_KEY_SIZE = 1024;
+  public static final int DEFAULT_KEY_SIZE = 2048;
 
   public static final int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
 


### PR DESCRIPTION
The updated openssl 1.1.1 in Debian has new default security settings and rejects certificates with RSA key size less than 2048 bits by default. voms-proxy-init generates proxies with a key size of 1024 bits by default. Trying to connect using these proxies from a Debian machine with openssl 1.1.1 fails. See e.g. the Debian BTS bug report https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911248.

This PR changes the default key size used by voms-proxy-init when generating proxies to 2048 bits.

The default key size used by grid-proxy-init has already been changed to 2048 bits (in both the old Globus Toolkit upstream and the new Grid Community Toolkit).
