### PR TITLE
Fix typo in man page

### DIFF
--- a/man/voms-proxy-info.1
+++ b/man/voms-proxy-info.1
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-voms-proxy-info \- prints informations about a proxy with VOMS extensions
+voms-proxy-info \- prints information about a proxy with VOMS extensions
 .SH "SYNOPSIS"
 .sp
 \fBvoms\-proxy\-info\fR [options]

--- a/man/voms-proxy-info.1.txt
+++ b/man/voms-proxy-info.1.txt
@@ -5,7 +5,7 @@ VOMS-PROXY-INFO(1)
 
 == NAME
 
-voms-proxy-info - prints informations about a proxy with VOMS extensions
+voms-proxy-info - prints information about a proxy with VOMS extensions
 
 
 == SYNOPSIS


### PR DESCRIPTION
Lintian reports:

I: voms-clients-java: typo-in-manual-page informations information [usr/share/man/man1/voms-proxy-info3.1.gz:31]