### PR TITLE
Upgrade voms-api-java version to 3.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ SPDX-License-Identifier: Apache-2.0
     <junit.version>4.13.2</junit.version>
     <commons-io.version>2.18.0</commons-io.version>
     <commons-cli.version>1.9.0</commons-cli.version>
-    <voms-api-java.version>3.3.4-SNAPSHOT</voms-api-java.version>
+    <voms-api-java.version>3.3.5-SNAPSHOT</voms-api-java.version>
 
     <!-- Leave this defined as empty -->
     <voms-clients.libs />
@@ -165,7 +165,6 @@ SPDX-License-Identifier: Apache-2.0
         <configuration>
           <source>17</source>
           <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
-          <reportOutputDirectory>${project.reporting.outputDirectory}/javadoc</reportOutputDirectory>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.italiangrid</groupId>
   <artifactId>voms-clients</artifactId>
-  <version>3.3.4</version>
+  <version>3.3.5</version>
 
   <name>voms-clients</name>
   <description>VOMS service command-line clients</description>
@@ -48,10 +48,10 @@ SPDX-License-Identifier: Apache-2.0
     <plugin.nexus-staging.version>1.6.3</plugin.nexus-staging.version>
     <plugin.asciidoctor.version>3.1.1</plugin.asciidoctor.version>
 
-    <junit.version>4.10</junit.version>
-    <commons-io.version>2.0.1</commons-io.version>
-    <commons-cli.version>1.2</commons-cli.version>
-    <voms-api-java.version>3.3.3</voms-api-java.version>
+    <junit.version>4.13.2</junit.version>
+    <commons-io.version>2.18.0</commons-io.version>
+    <commons-cli.version>1.9.0</commons-cli.version>
+    <voms-api-java.version>3.3.4-SNAPSHOT</voms-api-java.version>
 
     <!-- Leave this defined as empty -->
     <voms-clients.libs />
@@ -131,8 +131,8 @@ SPDX-License-Identifier: Apache-2.0
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${plugin.compiler.version}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
 
@@ -163,7 +163,7 @@ SPDX-License-Identifier: Apache-2.0
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${plugin.javadoc.version}</version>
         <configuration>
-          <source>1.8</source>
+          <source>17</source>
           <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
           <reportOutputDirectory>${project.reporting.outputDirectory}/javadoc</reportOutputDirectory>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,20 @@ SPDX-License-Identifier: Apache-2.0
     </developer>
   </developers>
 
+  <repositories>
+    <repository>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/org/italiangrid/voms/clients/AbstractCLI.java
+++ b/src/main/java/org/italiangrid/voms/clients/AbstractCLI.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -23,174 +23,205 @@ import org.italiangrid.voms.clients.util.VersionProvider;
 
 import eu.emi.security.authn.x509.impl.CertificateUtils;
 
+/**
+ * AbstractCLI provides a base class for command-line interface (CLI) tools.
+ * It handles command-line parsing, option initialization, and logging.
+ *
+ * <p>This class provides functionality such as:</p>
+ * <ul>
+ *   <li>Parsing command-line arguments and configuration files</li>
+ *   <li>Handling verbosity levels</li>
+ *   <li>Displaying help and version information</li>
+ * </ul>
+ *
+ * @author Istituto Nazionale di Fisica Nucleare
+ * @since 2006
+ */
 public abstract class AbstractCLI {
 
   static {
-
+    // Configure the security provider for certificate handling
     CertificateUtils.configureSecProvider();
   }
 
+  /** Default temporary file path **/
   public static final String DEFAULT_TMP_PATH = "/tmp";
 
-  /** The CLI options **/
+  /** CLI options container **/
   protected Options cliOptions;
 
-  /** The CLI options parser **/
-  protected CommandLineParser cliParser = new GnuParser();
+  /** Parser for command-line options **/
+  protected CommandLineParser cliParser = new DefaultParser();
 
-  /** The parsed command line **/
+  /** Parsed command-line arguments **/
   protected CommandLine commandLine = null;
 
-  /** The name of this command **/
+  /** Name of the command **/
   protected String commandName;
 
-  /** The logger used to print messages **/
+  /** Logger for displaying messages **/
   protected MessageLogger logger;
 
-  /** Be quiet when logging **/
+  /** Flag indicating quiet mode **/
   boolean isQuiet = false;
 
-  /** Be verbose when logging **/
+  /** Flag indicating verbose mode **/
   boolean isVerbose = false;
 
+  /**
+   * Constructs an AbstractCLI instance with the specified command name.
+   *
+   * @param commandName the name of the command
+   */
   protected AbstractCLI(String commandName) {
-
     this.commandName = commandName;
   }
 
+  /**
+   * Displays the usage information for the command.
+   */
   protected final void displayUsage() {
-
     int lineWidth = 120;
     String header = "options:";
     String footer = "";
-
     HelpFormatter helpFormatter = new HelpFormatter();
     helpFormatter.printHelp(lineWidth, commandName + " [options]", header,
       cliOptions, footer);
-
   }
 
+  /**
+   * Parses options from the command-line arguments.
+   *
+   * @param args the command-line arguments
+   */
   protected final void parseOptionsFromCommandLine(String[] args) {
-
     try {
-
       commandLine = cliParser.parse(cliOptions, args);
       if (commandLineHasOption(CommonOptions.CONF)) {
         parseOptionsFromFile(getOptionValue(CommonOptions.CONF));
       }
-
       setVerbosityFromCommandLine();
       displayVersionIfRequested();
       displayHelpIfRequested();
-
     } catch (ParseException e) {
-
-      System.err.println("Error parsing command line arguments: "
-        + e.getMessage());
+      System.err.println("Error parsing command line arguments: " + e.getMessage());
       displayUsage();
       System.exit(1);
     }
   }
 
   /**
-   * Parse options from a file. Reload commandLine that after calling this
-   * method contains both options coming from the command line and from the
-   * file.
-   * 
-   * @param optionFileName
-   *          the options file
-   * @throws ParseException
-   *           if there an error parsing the options
+   * Parses options from a file and merges them with command-line arguments.
+   *
+   * @param optionFileName the options file
+   * @throws ParseException if an error occurs while parsing options
    */
-  @SuppressWarnings("unchecked")
-  private void parseOptionsFromFile(String optionFileName)
-    throws ParseException {
-
+  private void parseOptionsFromFile(String optionFileName) throws ParseException {
     List<String> options = OptionsFileLoader.loadOptions(optionFileName);
     options.addAll(commandLine.getArgList());
-
     commandLine = cliParser.parse(cliOptions, options.toArray(new String[0]));
   }
 
+  /**
+   * Displays version information.
+   */
   protected final void displayVersion() {
-
     VersionProvider.displayVersionInfo(commandName);
   }
 
+  /**
+   * Initializes the available CLI options.
+   *
+   * @param options a list of CLI options
+   */
   protected final void initOptions(List<CLIOption> options) {
-
     cliOptions = new Options();
-
-    for (CLIOption o : options)
+    for (CLIOption o : options) {
       cliOptions.addOption(o.getOption());
+    }
   }
 
+  /**
+   * Checks if a command-line option is present.
+   *
+   * @param option the CLI option
+   * @return true if the option is present, false otherwise
+   */
   protected final boolean commandLineHasOption(CLIOption option) {
-
     return commandLine.hasOption(option.getLongOptionName());
   }
 
   /**
-   * Checks the command line to see whether the display of this CLI
-   * 
+   * Displays help information if requested.
    */
   protected final void displayHelpIfRequested() {
-
-    if (commandLineHasOption(CommonOptions.HELP)
-      || commandLineHasOption(CommonOptions.USAGE)) {
+    if (commandLineHasOption(CommonOptions.HELP) || commandLineHasOption(CommonOptions.USAGE)) {
       displayUsage();
       System.exit(0);
     }
   }
 
+  /**
+   * Displays version information if requested.
+   */
   protected final void displayVersionIfRequested() {
-
     if (commandLineHasOption(CommonOptions.VERSION)) {
       displayVersion();
       System.exit(0);
     }
   }
 
+  /**
+   * Retrieves the value of a given command-line option.
+   *
+   * @param option the CLI option
+   * @return the option value, or null if not present
+   */
   protected final String getOptionValue(CLIOption option) {
-
-    if (commandLineHasOption(option))
+    if (commandLineHasOption(option)) {
       return commandLine.getOptionValue(option.getLongOptionName());
-
+    }
     return null;
   }
 
+  /**
+   * Retrieves a list of values for a given command-line option.
+   *
+   * @param option the CLI option
+   * @return a list of option values, or null if not present
+   */
   protected final List<String> getOptionValues(CLIOption option) {
-
     if (commandLineHasOption(option)) {
-
       String[] values = commandLine.getOptionValues(option.getLongOptionName());
       return Arrays.asList(values);
     }
-
     return null;
   }
 
+  /**
+   * Sets verbosity levels based on command-line options.
+   */
   protected final void setVerbosityFromCommandLine() {
-
-    if (commandLineHasOption(CommonOptions.DEBUG))
+    if (commandLineHasOption(CommonOptions.DEBUG)) {
       isVerbose = true;
-
-    if (commandLineHasOption(ProxyInitOptions.QUIET_MODE))
+    }
+    if (commandLineHasOption(ProxyInitOptions.QUIET_MODE)) {
       isQuiet = true;
-
-    if (isVerbose && isQuiet)
-      throw new VOMSError(
-        "Try to understand us: this command cannot be verbose and quiet at the same time!");
-
-    if (isVerbose)
+    }
+    if (isVerbose && isQuiet) {
+      throw new VOMSError("Command cannot be both verbose and quiet at the same time!");
+    }
+    if (isVerbose) {
       logger = new MessageLogger(MessageLogger.VERBOSE);
-
-    if (isQuiet)
+    } else if (isQuiet) {
       logger = new MessageLogger(MessageLogger.QUIET);
-
-    if (!isVerbose && !isQuiet)
+    } else {
       logger = new MessageLogger();
+    }
   }
 
+  /**
+   * Executes the CLI command. This method must be implemented by subclasses.
+   */
   protected abstract void execute();
 }

--- a/src/main/java/org/italiangrid/voms/clients/impl/DefaultVOMSCommandsParser.java
+++ b/src/main/java/org/italiangrid/voms/clients/impl/DefaultVOMSCommandsParser.java
@@ -12,11 +12,33 @@ import java.util.Map;
 
 import org.italiangrid.voms.clients.strategies.VOMSCommandsParsingStrategy;
 
+/**
+ * Default implementation of the {@link VOMSCommandsParsingStrategy} interface.
+ * This class is responsible for parsing VOMS commands into a structured format.
+ */
 public class DefaultVOMSCommandsParser implements VOMSCommandsParsingStrategy {
 
+  /**
+   * The character used to separate VO names from FQANs in command strings.
+   */
   public static final String COMMAND_SEPARATOR = ":";
+
+  /**
+   * The string representing a request for all available attributes.
+   */
   public static final String ALL_COMMAND_STRING = "all";
 
+  /**
+   * Parses a list of VOMS commands and organizes them into a map.
+   *
+   * @param commands A list of strings representing VOMS commands, where each
+   *                 command follows the format "vo[:fqan]".
+   * @return A map where the keys are VO names and the values are lists of
+   *         requested FQANs. If "all" is specified, no FQANs are added.
+   *         Returns {@code null} if the input list is {@code null}, or an
+   *         empty map if the input list is empty.
+   */
+  @Override
   public Map<String, List<String>> parseCommands(List<String> commands) {
 
     if (commands == null)

--- a/src/main/java/org/italiangrid/voms/clients/options/ProxyDestroyOptions.java
+++ b/src/main/java/org/italiangrid/voms/clients/options/ProxyDestroyOptions.java
@@ -6,25 +6,77 @@ package org.italiangrid.voms.clients.options;
 
 import org.apache.commons.cli.Option;
 
+/**
+ * Enumeration representing the command-line options for the proxy destruction command. This enum
+ * defines various options that can be used when executing the proxy destroy command.
+ *
+ * <p>
+ * Each option is associated with an {@link Option} object built using the
+ * {@link VOMSCLIOptionBuilder} utility.
+ * </p>
+ *
+ * <p>
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2006-2014.
+ * </p>
+ *
+ * @author Istituto Nazionale di Fisica Nucleare
+ * @version 1.0
+ */
 public enum ProxyDestroyOptions implements CLIOption {
 
-  HELP("help"), USAGE("usage"), VERSION("version"), DEBUG("debug"), QUIET(
-    "quiet"), FILE("file"), DRY("dry"), CONF("conf");
+  /** Help option, displays usage information. */
+  HELP("help"),
 
+  /** Usage option, provides details on how to use the command. */
+  USAGE("usage"),
+
+  /** Version option, displays version information. */
+  VERSION("version"),
+
+  /** Debug option, enables debug mode for detailed logs. */
+  DEBUG("debug"),
+
+  /** Quiet option, suppresses non-essential output. */
+  QUIET("quiet"),
+
+  /** File option, specifies a proxy file to be destroyed. */
+  FILE("file"),
+
+  /** Dry-run option, simulates the command without executing it. */
+  DRY("dry"),
+
+  /** Configuration file option, specifies a configuration file. */
+  CONF("conf");
+
+  /** The Apache Commons CLI {@link Option} representation of the command-line option. */
   private Option option;
 
+  /**
+   * Constructs a ProxyDestroyOptions enum with the specified long option name.
+   *
+   * @param longOpt the long option name
+   */
   private ProxyDestroyOptions(String longOpt) {
 
-    option = VOMSCLIOptionBuilder.buildOption(longOpt,
-      CLIOptionsBundle.proxyInfo);
+    option = VOMSCLIOptionBuilder.buildOption(longOpt, CLIOptionsBundle.proxyInfo);
   }
 
+  /**
+   * Returns the associated Apache Commons CLI {@link Option} object.
+   *
+   * @return the CLI option
+   */
   @Override
   public Option getOption() {
 
     return option;
   }
 
+  /**
+   * Returns the long option name of this command-line option.
+   *
+   * @return the long option name
+   */
   @Override
   public String getLongOptionName() {
 

--- a/src/main/java/org/italiangrid/voms/clients/util/OptionsFileLoader.java
+++ b/src/main/java/org/italiangrid/voms/clients/util/OptionsFileLoader.java
@@ -10,6 +10,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -43,7 +44,7 @@ public class OptionsFileLoader {
 
       InputStream inputStream = new FileInputStream(optionFile);
 
-      IOUtils.copy(inputStream, stringWriter);
+      IOUtils.copy(inputStream, stringWriter, Charset.defaultCharset());
 
     } catch (FileNotFoundException e) {
 


### PR DESCRIPTION
- Fix LSC parsing issue (fixed with voms-api-java 3.3.4)
- Upgrades to CANL v2.8.3 and Bouncy Castle v1.80
- Javadoc missing comments
- Move to Java 17