### PR TITLE
Validate LSC only for the requested VOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ SPDX-License-Identifier: Apache-2.0
     <junit.version>4.13.2</junit.version>
     <commons-io.version>2.18.0</commons-io.version>
     <commons-cli.version>1.9.0</commons-cli.version>
-    <voms-api-java.version>3.3.6</voms-api-java.version>
+    <voms-api-java.version>3.3.7-SNAPSHOT</voms-api-java.version>
 
     <!-- Leave this defined as empty -->
     <voms-clients.libs />


### PR DESCRIPTION
When one requests a proxy for one or more VOs (with `-voms` option), the attribute validation loads only the corresponding LSC file. For instance, when the second line in the broken LSC file does not start with a `/` character, we get a _Malformed LSC file_ error as follows:

```
$ voms-proxy-init -voms wlcg
LSC file parsing error: Malformed LSC file (vo=wlcg, host=wlcg-voms.cloud.cnaf.infn.it): Odd number of distinguished name entries.
```